### PR TITLE
Update rust edition to 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ readme = "README.md"
 keywords = ["git"]
 categories = ["command-line-utilities", "development-tools"]
 
+edition = "2018"
+
 [[bin]]
 name = "git-global"
 doc = false

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,10 +2,11 @@
 
 use std::io::{stderr, stdout, Write};
 
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand, crate_version};
+use json::object;
 
-use config::Config;
-use subcommands;
+use crate::config::Config;
+use crate::subcommands;
 
 /// Returns the definitive clap::App instance for git-global.
 fn get_clap_app<'a, 'b>() -> App<'a, 'b> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ use dirs::home_dir;
 use git2;
 use walkdir::{DirEntry, WalkDir};
 
-use repo::Repo;
+use crate::repo::Repo;
 
 const APP: AppInfo = AppInfo {
     name: "git-global",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,16 +47,6 @@
 //! [rfcl]: fn.run_from_command_line.html
 //! [subcommands]: subcommands/index.html
 
-extern crate app_dirs;
-extern crate chrono;
-#[macro_use]
-extern crate clap;
-extern crate dirs;
-extern crate git2;
-#[macro_use]
-extern crate json;
-extern crate walkdir;
-
 mod cli;
 mod config;
 mod errors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 //! Entry point for the binary.
 
-extern crate git_global;
-
 use std::process::exit;
 
 /// Runs git-global from the command line, exiting with its return value.

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,7 +3,9 @@
 use std::collections::HashMap;
 use std::io::Write;
 
-use repo::Repo;
+use json::{object, array};
+
+use crate::repo::Repo;
 
 /// A report containing the results of a git-global subcommand.
 ///

--- a/src/subcommands/info.rs
+++ b/src/subcommands/info.rs
@@ -1,13 +1,14 @@
 //! The `info` subcommand: shows metadata about the git-global installation.
 
 use chrono::Duration;
+use clap::crate_version;
 
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-use config::Config;
-use errors::Result;
-use report::Report;
+use crate::config::Config;
+use crate::errors::Result;
+use crate::report::Report;
 
 /// Returns the age of a file in terms of days, hours, minutes, and seconds.
 fn get_age(filename: PathBuf) -> Option<String> {

--- a/src/subcommands/list.rs
+++ b/src/subcommands/list.rs
@@ -1,8 +1,8 @@
 //! The `list` subcommand: lists all repos known to git-global.
 
-use config::Config;
-use errors::Result;
-use report::Report;
+use crate::config::Config;
+use crate::errors::Result;
+use crate::report::Report;
 
 /// Forces the display of each repo path, without any extra output.
 pub fn execute(mut config: Config) -> Result<Report> {

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -7,9 +7,9 @@ pub mod stashed;
 pub mod status;
 pub mod unstaged;
 
-use config::Config;
-use errors::{GitGlobalError, Result};
-use report::Report;
+use crate::config::Config;
+use crate::errors::{GitGlobalError, Result};
+use crate::report::Report;
 
 /// Run the subcommand matching the provided `str`, returning a `Report`.
 pub fn run(command: &str, config: Config) -> Result<Report> {

--- a/src/subcommands/scan.rs
+++ b/src/subcommands/scan.rs
@@ -10,9 +10,9 @@
 //! The `scan` subcommand caches the list of git repos paths it finds, and can
 //! be rerun at any time to refresh the list.
 
-use config::Config;
-use errors::Result;
-use report::Report;
+use crate::config::Config;
+use crate::errors::Result;
+use crate::report::Report;
 
 /// Clears the cache, forces a rescan, and says how many repos were found.
 pub fn execute(mut config: Config) -> Result<Report> {

--- a/src/subcommands/staged.rs
+++ b/src/subcommands/staged.rs
@@ -6,10 +6,10 @@ use std::thread;
 
 use git2;
 
-use config::Config;
-use errors::Result;
-use repo::Repo;
-use report::Report;
+use crate::config::Config;
+use crate::errors::Result;
+use crate::repo::Repo;
+use crate::report::Report;
 
 /// Runs the `staged` subcommand.
 pub fn execute(mut config: Config) -> Result<Report> {

--- a/src/subcommands/stashed.rs
+++ b/src/subcommands/stashed.rs
@@ -3,10 +3,10 @@
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-use config::Config;
-use errors::Result;
-use repo::Repo;
-use report::Report;
+use crate::config::Config;
+use crate::errors::Result;
+use crate::repo::Repo;
+use crate::report::Report;
 
 /// Runs the `stashed` subcommand.
 pub fn execute(mut config: Config) -> Result<Report> {

--- a/src/subcommands/status.rs
+++ b/src/subcommands/status.rs
@@ -6,10 +6,10 @@ use std::thread;
 
 use git2;
 
-use config::Config;
-use errors::Result;
-use repo::Repo;
-use report::Report;
+use crate::config::Config;
+use crate::errors::Result;
+use crate::repo::Repo;
+use crate::report::Report;
 
 /// Runs the `status` subcommand.
 pub fn execute(mut config: Config) -> Result<Report> {

--- a/src/subcommands/unstaged.rs
+++ b/src/subcommands/unstaged.rs
@@ -6,10 +6,10 @@ use std::thread;
 
 use git2;
 
-use config::Config;
-use errors::Result;
-use repo::Repo;
-use report::Report;
+use crate::config::Config;
+use crate::errors::Result;
+use crate::repo::Repo;
+use crate::report::Report;
 
 /// Runs the `unstaged` subcommand.
 pub fn execute(mut config: Config) -> Result<Report> {

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -1,14 +1,10 @@
-#[macro_use]
-extern crate clap;
-extern crate git_global;
-extern crate regex;
-
 mod utils;
 
 use std::io::Cursor;
 use std::path::PathBuf;
 
 use regex::{escape, Regex};
+use clap::crate_version;
 
 use git_global::{subcommands, Report};
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,10 +1,6 @@
-extern crate git2;
-extern crate git_global;
-extern crate tempdir;
-
 use std::path::PathBuf;
 
-use self::git_global::{Config, Repo};
+use git_global::{Config, Repo};
 
 /// Initialize an empty git repo in a temporary directory, then run a closure
 /// that takes that Repo instance.


### PR DESCRIPTION
Bumps the rust edition to 2018

The `crate` prefix have been added for internal mod usage and all occurrences of `extern crate` which are not mandatory anymore have been removed.