### PR TITLE
Adds an `unpushed` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Use `git global <subcommand>` to:
 * `git global status`: show `git status -s` for all your repos with any changes
 * `git global unstaged`: show status of the working directory for repos with
   such changes
+- `git global ahead`: show list of repos where branches contains commits that
+not present on any of the remotes.
 
 ## Command-line flags
 

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -1,11 +1,11 @@
 //! Subcommand implementations and dispatch function `run()`.
+pub mod ahead;
 pub mod info;
 pub mod list;
 pub mod scan;
 pub mod staged;
 pub mod stashed;
 pub mod status;
-pub mod unpushed;
 pub mod unstaged;
 
 use crate::config::Config;
@@ -26,7 +26,7 @@ pub fn run(maybe_subcmd: Option<&str>, config: Config) -> Result<Report> {
         "stashed" => stashed::execute(config),
         "status" => status::execute(config),
         "unstaged" => unstaged::execute(config),
-        "unpushed" => unpushed::execute(config),
+        "ahead" => ahead::execute(config),
         cmd => Err(GitGlobalError::BadSubcommand(cmd.to_string())),
     }
 }
@@ -53,7 +53,7 @@ pub fn get_subcommands() -> Vec<(&'static str, &'static str)> {
             "Show working dir status for repos with unstaged changes",
         ),
         (
-            "unpushed",
+            "ahead",
             "Shows repos with changes that are not pushed to a remote",
         ),
     ]

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -5,6 +5,7 @@ pub mod scan;
 pub mod staged;
 pub mod stashed;
 pub mod status;
+pub mod unpushed;
 pub mod unstaged;
 
 use crate::config::Config;
@@ -25,6 +26,7 @@ pub fn run(maybe_subcmd: Option<&str>, config: Config) -> Result<Report> {
         "stashed" => stashed::execute(config),
         "status" => status::execute(config),
         "unstaged" => unstaged::execute(config),
+        "unpushed" => unpushed::execute(config),
         cmd => Err(GitGlobalError::BadSubcommand(cmd.to_string())),
     }
 }
@@ -49,6 +51,10 @@ pub fn get_subcommands() -> Vec<(&'static str, &'static str)> {
         (
             "unstaged",
             "Show working dir status for repos with unstaged changes",
+        ),
+        (
+            "unpushed",
+            "Shows repos with changes that are not pushed to a remote",
         ),
     ]
 }

--- a/src/subcommands/ahead.rs
+++ b/src/subcommands/ahead.rs
@@ -1,4 +1,4 @@
-//! The `unpushed` subcommand: shows repositories that have commits not pushed to a remote
+//! The `ahead` subcommand: shows repositories that have commits not pushed to a remote
 
 use std::sync::{mpsc, Arc};
 use std::thread;
@@ -8,7 +8,7 @@ use crate::errors::Result;
 use crate::repo::Repo;
 use crate::report::Report;
 
-/// Runs the `unpushed` subcommand.
+/// Runs the `ahead` subcommand.
 pub fn execute(mut config: Config) -> Result<Report> {
     let repos = config.get_repos();
     let n_repos = repos.len();
@@ -20,14 +20,14 @@ pub fn execute(mut config: Config) -> Result<Report> {
         let repo = Arc::new(repo);
         thread::spawn(move || {
             let path = repo.path();
-            let synced = repo.is_origin_synced();
-            tx.send((path, synced)).unwrap();
+            let ahead = repo.is_ahead();
+            tx.send((path, ahead)).unwrap();
         });
     }
     for _ in 0..n_repos {
-        let (path, synced) = rx.recv().unwrap();
+        let (path, ahead) = rx.recv().unwrap();
         let repo = Repo::new(path.to_string());
-        if !synced {
+        if ahead {
             report.add_repo_message(&repo, format!(""));
         }
     }

--- a/src/subcommands/unpushed.rs
+++ b/src/subcommands/unpushed.rs
@@ -1,0 +1,35 @@
+//! The `unpushed` subcommand: shows repositories that have commits not pushed to a remote
+
+use std::sync::{mpsc, Arc};
+use std::thread;
+
+use crate::config::Config;
+use crate::errors::Result;
+use crate::repo::Repo;
+use crate::report::Report;
+
+/// Runs the `unpushed` subcommand.
+pub fn execute(mut config: Config) -> Result<Report> {
+    let repos = config.get_repos();
+    let n_repos = repos.len();
+    let mut report = Report::new(&repos);
+    // TODO: limit number of threads, perhaps with mpsc::sync_channel(n)?
+    let (tx, rx) = mpsc::channel();
+    for repo in repos {
+        let tx = tx.clone();
+        let repo = Arc::new(repo);
+        thread::spawn(move || {
+            let path = repo.path();
+            let synced = repo.is_origin_synced();
+            tx.send((path, synced)).unwrap();
+        });
+    }
+    for _ in 0..n_repos {
+        let (path, synced) = rx.recv().unwrap();
+        let repo = Repo::new(path.to_string());
+        if !synced {
+            report.add_repo_message(&repo, format!(""));
+        }
+    }
+    Ok(report)
+}


### PR DESCRIPTION
This pull request adds a feature that I called `unpushed` (I don't know if the name is good). This feature let you know what branches are not pushed on a remote.

## Todo (if accepted)

- [ ] document the function
- [ ] tests ?
- [ ] remove unwrap ?

## Limitations

It does not take into account staged and unstaged changes, as I think this may be in the scope of the dirty function.
It may not work if you have cloned using --depth=1 as the commits of the remotes will not be stored locally.

## Enhancements

I though to options specific to this command, if this feature is though to be useful :

- selecting remotes that have distant URL : you may not want to look at local remotes that are just a local folder
- selecting specific branches (maybe you want to ignore local `dirty/*` branches)

## Sidenotes :

Is this feature also in the scope of the dirty function ? Maybe it would be nice to have an opinionated function that tells you which repositories may require an intervention to avoid to lose your work. (unpushed, staged and unstaged, maybe even stashed)



